### PR TITLE
Introduced configuration option to allow temporary access to unverified accounts

### DIFF
--- a/NuGet/BrockAllen.MembershipReboot.da/BrockAllen.MembershipReboot.nuspec
+++ b/NuGet/BrockAllen.MembershipReboot.da/BrockAllen.MembershipReboot.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>BrockAllen.MembershipReboot.da</id>
-    <version>8.3.0</version>
+    <version>8.4.0</version>
     <authors>BrockAllen</authors>
     <owners>BrockAllen</owners>
     <licenseUrl>https://raw.github.com/brockallen/BrockAllen.MembershipReboot/master/license.txt</licenseUrl>
@@ -16,7 +16,7 @@
     <language>da</language>
 
     <dependencies>
-		<dependency id="BrockAllen.MembershipReboot" version="[8.3.0]" />
+		<dependency id="BrockAllen.MembershipReboot" version="[8.4.0]" />
     </dependencies>
   </metadata>
 </package>

--- a/NuGet/BrockAllen.MembershipReboot.da/BrockAllen.MembershipReboot.nuspec
+++ b/NuGet/BrockAllen.MembershipReboot.da/BrockAllen.MembershipReboot.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>BrockAllen.MembershipReboot.da</id>
-    <version>8.4.0</version>
+    <version>8.5.0</version>
     <authors>BrockAllen</authors>
     <owners>BrockAllen</owners>
     <licenseUrl>https://raw.github.com/brockallen/BrockAllen.MembershipReboot/master/license.txt</licenseUrl>

--- a/NuGet/BrockAllen.MembershipReboot.de/BrockAllen.MembershipReboot.nuspec
+++ b/NuGet/BrockAllen.MembershipReboot.de/BrockAllen.MembershipReboot.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>BrockAllen.MembershipReboot.de</id>
-    <version>8.3.0</version>
+    <version>8.4.0</version>
     <authors>BrockAllen</authors>
     <owners>BrockAllen</owners>
     <licenseUrl>https://raw.github.com/brockallen/BrockAllen.MembershipReboot/master/license.txt</licenseUrl>
@@ -16,7 +16,7 @@
     <language>de</language>
 
     <dependencies>
-		<dependency id="BrockAllen.MembershipReboot" version="[8.3.0]" />
+		<dependency id="BrockAllen.MembershipReboot" version="[8.4.0]" />
     </dependencies>
   </metadata>
 </package>

--- a/NuGet/BrockAllen.MembershipReboot.de/BrockAllen.MembershipReboot.nuspec
+++ b/NuGet/BrockAllen.MembershipReboot.de/BrockAllen.MembershipReboot.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>BrockAllen.MembershipReboot.de</id>
-    <version>8.4.0</version>
+    <version>8.5.0</version>
     <authors>BrockAllen</authors>
     <owners>BrockAllen</owners>
     <licenseUrl>https://raw.github.com/brockallen/BrockAllen.MembershipReboot/master/license.txt</licenseUrl>

--- a/NuGet/BrockAllen.MembershipReboot.nl/BrockAllen.MembershipReboot.nuspec
+++ b/NuGet/BrockAllen.MembershipReboot.nl/BrockAllen.MembershipReboot.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>BrockAllen.MembershipReboot.nl</id>
-    <version>8.3.0</version>
+    <version>8.4.0</version>
     <authors>BrockAllen</authors>
     <owners>BrockAllen</owners>
     <licenseUrl>https://raw.github.com/brockallen/BrockAllen.MembershipReboot/master/license.txt</licenseUrl>
@@ -16,7 +16,7 @@
     <language>nl</language>
 
     <dependencies>
-		<dependency id="BrockAllen.MembershipReboot" version="[8.3.0]" />
+		<dependency id="BrockAllen.MembershipReboot" version="[8.4.0]" />
     </dependencies>
   </metadata>
 </package>

--- a/NuGet/BrockAllen.MembershipReboot.nl/BrockAllen.MembershipReboot.nuspec
+++ b/NuGet/BrockAllen.MembershipReboot.nl/BrockAllen.MembershipReboot.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>BrockAllen.MembershipReboot.nl</id>
-    <version>8.4.0</version>
+    <version>8.5.0</version>
     <authors>BrockAllen</authors>
     <owners>BrockAllen</owners>
     <licenseUrl>https://raw.github.com/brockallen/BrockAllen.MembershipReboot/master/license.txt</licenseUrl>

--- a/NuGet/BrockAllen.MembershipReboot.no/BrockAllen.MembershipReboot.nuspec
+++ b/NuGet/BrockAllen.MembershipReboot.no/BrockAllen.MembershipReboot.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>BrockAllen.MembershipReboot.no</id>
-    <version>8.4.0</version>
+    <version>8.5.0</version>
     <authors>BrockAllen</authors>
     <owners>BrockAllen</owners>
     <licenseUrl>https://raw.github.com/brockallen/BrockAllen.MembershipReboot/master/license.txt</licenseUrl>

--- a/NuGet/BrockAllen.MembershipReboot.no/BrockAllen.MembershipReboot.nuspec
+++ b/NuGet/BrockAllen.MembershipReboot.no/BrockAllen.MembershipReboot.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>BrockAllen.MembershipReboot.no</id>
-    <version>8.3.0</version>
+    <version>8.4.0</version>
     <authors>BrockAllen</authors>
     <owners>BrockAllen</owners>
     <licenseUrl>https://raw.github.com/brockallen/BrockAllen.MembershipReboot/master/license.txt</licenseUrl>
@@ -16,7 +16,7 @@
     <language>no</language>
 
     <dependencies>
-		<dependency id="BrockAllen.MembershipReboot" version="[8.3.0]" />
+		<dependency id="BrockAllen.MembershipReboot" version="[8.4.0]" />
     </dependencies>
   </metadata>
 </package>

--- a/NuGet/BrockAllen.MembershipReboot.ru/BrockAllen.MembershipReboot.nuspec
+++ b/NuGet/BrockAllen.MembershipReboot.ru/BrockAllen.MembershipReboot.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>BrockAllen.MembershipReboot.ru</id>
-    <version>8.4.0</version>
+    <version>8.5.0</version>
     <authors>BrockAllen</authors>
     <owners>BrockAllen</owners>
     <licenseUrl>https://raw.github.com/brockallen/BrockAllen.MembershipReboot/master/license.txt</licenseUrl>

--- a/NuGet/BrockAllen.MembershipReboot.ru/BrockAllen.MembershipReboot.nuspec
+++ b/NuGet/BrockAllen.MembershipReboot.ru/BrockAllen.MembershipReboot.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>BrockAllen.MembershipReboot.ru</id>
-    <version>8.3.0</version>
+    <version>8.4.0</version>
     <authors>BrockAllen</authors>
     <owners>BrockAllen</owners>
     <licenseUrl>https://raw.github.com/brockallen/BrockAllen.MembershipReboot/master/license.txt</licenseUrl>
@@ -16,7 +16,7 @@
     <language>ru</language>
 
     <dependencies>
-		<dependency id="BrockAllen.MembershipReboot" version="[8.3.0]" />
+		<dependency id="BrockAllen.MembershipReboot" version="[8.4.0]" />
     </dependencies>
   </metadata>
 </package>

--- a/NuGet/BrockAllen.MembershipReboot.sv/BrockAllen.MembershipReboot.nuspec
+++ b/NuGet/BrockAllen.MembershipReboot.sv/BrockAllen.MembershipReboot.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>BrockAllen.MembershipReboot.sv</id>
-    <version>8.3.0</version>
+    <version>8.4.0</version>
     <authors>BrockAllen</authors>
     <owners>BrockAllen</owners>
     <licenseUrl>https://raw.github.com/brockallen/BrockAllen.MembershipReboot/master/license.txt</licenseUrl>
@@ -16,7 +16,7 @@
     <language>sv</language>
 
     <dependencies>
-		<dependency id="BrockAllen.MembershipReboot" version="[8.3.0]" />
+		<dependency id="BrockAllen.MembershipReboot" version="[8.4.0]" />
     </dependencies>
   </metadata>
 </package>

--- a/NuGet/BrockAllen.MembershipReboot.sv/BrockAllen.MembershipReboot.nuspec
+++ b/NuGet/BrockAllen.MembershipReboot.sv/BrockAllen.MembershipReboot.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>BrockAllen.MembershipReboot.sv</id>
-    <version>8.4.0</version>
+    <version>8.5.0</version>
     <authors>BrockAllen</authors>
     <owners>BrockAllen</owners>
     <licenseUrl>https://raw.github.com/brockallen/BrockAllen.MembershipReboot/master/license.txt</licenseUrl>

--- a/NuGet/BrockAllen.MembershipReboot.zh/BrockAllen.MembershipReboot.nuspec
+++ b/NuGet/BrockAllen.MembershipReboot.zh/BrockAllen.MembershipReboot.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>BrockAllen.MembershipReboot.zh</id>
-    <version>8.4.0</version>
+    <version>8.5.0</version>
     <authors>BrockAllen</authors>
     <owners>BrockAllen</owners>
     <licenseUrl>https://raw.github.com/brockallen/BrockAllen.MembershipReboot/master/license.txt</licenseUrl>

--- a/NuGet/BrockAllen.MembershipReboot.zh/BrockAllen.MembershipReboot.nuspec
+++ b/NuGet/BrockAllen.MembershipReboot.zh/BrockAllen.MembershipReboot.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>BrockAllen.MembershipReboot.zh</id>
-    <version>8.3.0</version>
+    <version>8.4.0</version>
     <authors>BrockAllen</authors>
     <owners>BrockAllen</owners>
     <licenseUrl>https://raw.github.com/brockallen/BrockAllen.MembershipReboot/master/license.txt</licenseUrl>
@@ -16,7 +16,7 @@
     <language>zh</language>
 
     <dependencies>
-		<dependency id="BrockAllen.MembershipReboot" version="[8.3.0]" />
+		<dependency id="BrockAllen.MembershipReboot" version="[8.4.0]" />
     </dependencies>
   </metadata>
 </package>

--- a/NuGet/BrockAllen.MembershipReboot/BrockAllen.MembershipReboot.nuspec
+++ b/NuGet/BrockAllen.MembershipReboot/BrockAllen.MembershipReboot.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>BrockAllen.MembershipReboot</id>
-    <version>8.4.0</version>
+    <version>8.5.0</version>
     <authors>BrockAllen</authors>
     <owners>BrockAllen</owners>
     <licenseUrl>https://raw.github.com/brockallen/BrockAllen.MembershipReboot/master/license.txt</licenseUrl>

--- a/src/BrockAllen.MembershipReboot.Test/AccountService/UserAccountServiceTests.cs
+++ b/src/BrockAllen.MembershipReboot.Test/AccountService/UserAccountServiceTests.cs
@@ -810,6 +810,34 @@ namespace BrockAllen.MembershipReboot.Test.AccountService
         }
 
         [TestMethod]
+        public void VerifyEmailFromKey_Success_Raises_EmailVerifiedEvent_New_Account()
+        {
+            var emailVerifiedEvent = CaptureLatestEvent.For<EmailVerifiedEvent<UserAccount>>();
+            configuration.AddEventHandler(emailVerifiedEvent);
+            configuration.AllowLoginAfterAccountCreation = true;
+            configuration.RequireAccountVerification = true;
+            subject.CreateAccount("test", "pass", "test@test.com");
+
+            subject.VerifyEmailFromKey(LastVerificationKey, "pass");
+            Assert.IsTrue(emailVerifiedEvent.Latest.IsNewAccount);
+        }
+
+        [TestMethod]
+        public void VerifyEmailFromKey_Success_Raises_EmailVerifiedEvent_Account_Existing_Account()
+        {
+            var emailVerifiedEvent = CaptureLatestEvent.For<EmailVerifiedEvent<UserAccount>>();
+            configuration.AddEventHandler(emailVerifiedEvent);
+            configuration.AllowLoginAfterAccountCreation = true;
+            configuration.RequireAccountVerification = true;
+            var account = subject.CreateAccount("test", "pass", "test@test.com");
+            subject.VerifyEmailFromKey(LastVerificationKey, "pass");
+            subject.ChangeEmailRequest(account.ID, account.Email);
+
+            subject.VerifyEmailFromKey(LastVerificationKey, "pass");
+            Assert.IsFalse(emailVerifiedEvent.Latest.IsNewAccount);
+        }
+
+        [TestMethod]
         public void CancelVerification_CloseAccount()
         {
             var acct = subject.CreateAccount("test", "pass", "test@test.com");

--- a/src/BrockAllen.MembershipReboot.Test/AccountService/UserAccountServiceTests.cs
+++ b/src/BrockAllen.MembershipReboot.Test/AccountService/UserAccountServiceTests.cs
@@ -1053,6 +1053,32 @@ namespace BrockAllen.MembershipReboot.Test.AccountService
         }
 
         [TestMethod]
+        public void Authenticate_AccountNotVerified_VerificationWindowOpen_LoginAllowed()
+        {
+            this.configuration.RequireAccountVerification = true;
+            this.configuration.AllowUnverifiedAccountsWindow = TimeSpan.FromDays(1);
+            
+            subject.Now = new DateTime(2016, 2, 1, 11, 53, 0);
+            var acc = subject.CreateAccount("test", "pass", "test@test.com");
+            Assert.IsTrue(subject.Authenticate("test", "pass"));
+        }
+
+        [TestMethod]
+        public void Authenticate_AccountNotVerified_VerificationWindowOpen_Fails()
+        {
+            this.configuration.RequireAccountVerification = true;
+            this.configuration.AllowUnverifiedAccountsWindow = TimeSpan.FromDays(1);
+            var unvarifiedAccountAccessWindow = this.configuration.AllowUnverifiedAccountsWindow = TimeSpan.FromDays(1);
+
+            subject.Now = new DateTime(2016, 2, 1, 11, 53, 0);
+            var acc = subject.CreateAccount("test", "pass", "test@test.com");
+            subject.Now += unvarifiedAccountAccessWindow.Value.Add(TimeSpan.FromMilliseconds(1));
+            AuthenticationFailureCode failureCode;
+            Assert.IsFalse(subject.Authenticate("test", "pass", out failureCode));
+            Assert.AreEqual(AuthenticationFailureCode.AccountNotVerified, failureCode);
+        }
+
+        [TestMethod]
         public void Authenticate_LoginNotAllowed_Fails()
         {
             this.configuration.RequireAccountVerification = false;

--- a/src/BrockAllen.MembershipReboot.Test/BrockAllen.MembershipReboot.Test.csproj
+++ b/src/BrockAllen.MembershipReboot.Test/BrockAllen.MembershipReboot.Test.csproj
@@ -55,6 +55,7 @@
   </Choose>
   <ItemGroup>
     <Compile Include="Authentication\SignInTests.cs" />
+    <Compile Include="CaptureLatestEvent.cs" />
     <Compile Include="GroupService\FakeGroupRepository.cs" />
     <Compile Include="GroupService\GroupServiceTests.cs" />
     <Compile Include="Authentication\SignInWithLinkedAccountTests.cs" />

--- a/src/BrockAllen.MembershipReboot.Test/CaptureLatestEvent.cs
+++ b/src/BrockAllen.MembershipReboot.Test/CaptureLatestEvent.cs
@@ -1,0 +1,19 @@
+namespace BrockAllen.MembershipReboot.Test
+{
+    public class CaptureLatestEvent<TEvent, TAccount> : IEventHandler<TEvent> where TEvent: UserAccountEvent<TAccount>
+    {
+        public TEvent Latest { get; set; }
+        public void Handle(TEvent evt)
+        {
+            Latest = evt;
+        }
+    }
+
+    public static class CaptureLatestEvent
+    {
+        public static CaptureLatestEvent<TEvent, UserAccount> For<TEvent>() where TEvent : UserAccountEvent<UserAccount>
+        {
+            return new CaptureLatestEvent<TEvent, UserAccount>();
+        }
+    }
+}

--- a/src/BrockAllen.MembershipReboot.Test/FakeUserAccountRepository.cs
+++ b/src/BrockAllen.MembershipReboot.Test/FakeUserAccountRepository.cs
@@ -6,6 +6,7 @@ namespace BrockAllen.MembershipReboot.Test
 {
     public class MyUserAccount : HierarchicalUserAccount 
     {
+        public string FirstName { get; set; }
         protected internal override void AddClaim(UserClaim item)
         {
             base.AddClaim(item);

--- a/src/BrockAllen.MembershipReboot/AccountService/UserAccountEvents.cs
+++ b/src/BrockAllen.MembershipReboot/AccountService/UserAccountEvents.cs
@@ -70,7 +70,11 @@ namespace BrockAllen.MembershipReboot
         public string OldEmail { get; set; }
         public string VerificationKey { get; set; }
     }
-    public class EmailVerifiedEvent<T> : UserAccountEvent<T> { }
+
+    public class EmailVerifiedEvent<T> : UserAccountEvent<T>
+    {
+        public bool IsNewAccount { get; set; }
+    }
 
     public class MobilePhoneChangeRequestedEvent<T> : UserAccountEvent<T>
     {

--- a/src/BrockAllen.MembershipReboot/AccountService/UserAccountService.cs
+++ b/src/BrockAllen.MembershipReboot/AccountService/UserAccountService.cs
@@ -988,7 +988,7 @@ namespace BrockAllen.MembershipReboot
                     }
 
                     if (Configuration.RequireAccountVerification &&
-                        !account.IsAccountVerified)
+                        (!account.IsAccountVerified && UnverifiedAccountAllowanceHasExpired(account)))
                     {
                         Tracing.Error("[UserAccountService.Authenticate] failed -- account not verified");
                         this.AddEvent(new AccountNotVerifiedEvent<TAccount>() { Account = account });
@@ -1056,6 +1056,16 @@ namespace BrockAllen.MembershipReboot
             Tracing.Verbose("[UserAccountService.Authenticate] authentication outcome: {0}", result ? "Successful Login" : "Failed Login");
 
             return result;
+        }
+
+        private bool UnverifiedAccountAllowanceHasExpired(TAccount account)
+        {
+            if (Configuration.AllowUnverifiedAccountsWindow.HasValue)
+            {
+                return account.Created.Add(Configuration.AllowUnverifiedAccountsWindow.Value) < UtcNow;
+            }
+
+            return true;
         }
 
         protected virtual bool Authenticate(TAccount account, string password)

--- a/src/BrockAllen.MembershipReboot/AccountService/UserAccountService.cs
+++ b/src/BrockAllen.MembershipReboot/AccountService/UserAccountService.cs
@@ -1837,13 +1837,14 @@ namespace BrockAllen.MembershipReboot
             // one last check
             ValidateEmail(account, account.VerificationStorage);
 
+            bool isNewAccount = account.IsNew();
             account.Email = account.VerificationStorage;
             account.IsAccountVerified = true;
             account.LastLogin = UtcNow;
 
             ClearVerificationKey(account);
 
-            this.AddEvent(new EmailVerifiedEvent<TAccount> { Account = account });
+            this.AddEvent(new EmailVerifiedEvent<TAccount> { Account = account, IsNewAccount = isNewAccount });
 
             if (Configuration.EmailIsUsername)
             {

--- a/src/BrockAllen.MembershipReboot/Authentication/AuthenticationService.cs
+++ b/src/BrockAllen.MembershipReboot/Authentication/AuthenticationService.cs
@@ -253,12 +253,14 @@ namespace BrockAllen.MembershipReboot
                     // create account without password -- user can verify their email and then 
                     // do a password reset to assign password
                     Tracing.Verbose("[AuthenticationService.SignInWithLinkedAccount] creating account: {0}, {1}", name, email);
-                    account = this.UserAccountService.CreateAccount(tenant, name, null, email);
-
+                    
+                    account = this.UserAccountService.CreateUserAccount();
+                    
                     // update account with external claims
                     var cmd = new MapClaimsToAccount<TAccount> { Account = account, Claims = claims };
                     this.UserAccountService.ExecuteCommand(cmd);
-                    this.UserAccountService.Update(account);
+
+                    this.UserAccountService.CreateAccount(tenant, name, null, email, account: account);
                 }
                 else
                 {

--- a/src/BrockAllen.MembershipReboot/Configuration/MembershipRebootConfiguration.cs
+++ b/src/BrockAllen.MembershipReboot/Configuration/MembershipRebootConfiguration.cs
@@ -31,7 +31,8 @@ namespace BrockAllen.MembershipReboot
             this.AllowAccountDeletion = securitySettings.AllowAccountDeletion;
             this.PasswordHashingIterationCount = securitySettings.PasswordHashingIterationCount;
             this.PasswordResetFrequency = securitySettings.PasswordResetFrequency;
-            this.VerificationKeyLifetime = securitySettings.VerificationKeyLifetime;
+            this.AllowUnverifiedAccountsWindow = securitySettings.AllowUnverifiedAccountsWindow;
+            this.VerificationKeyLifetime = securitySettings.AllowUnverifiedAccountsWindow ?? securitySettings.VerificationKeyLifetime;
 
             this.Crypto = new DefaultCrypto();
         }
@@ -49,6 +50,7 @@ namespace BrockAllen.MembershipReboot
         public int PasswordHashingIterationCount { get; set; }
         public int PasswordResetFrequency { get; set; }
         public TimeSpan VerificationKeyLifetime { get; set; }
+        public TimeSpan? AllowUnverifiedAccountsWindow { get; set; }
 
         internal void Validate()
         {

--- a/src/BrockAllen.MembershipReboot/Configuration/SecuritySettings.cs
+++ b/src/BrockAllen.MembershipReboot/Configuration/SecuritySettings.cs
@@ -53,6 +53,7 @@ namespace BrockAllen.MembershipReboot
         private const string PASSWORDHASHINGITERATIONCOUNT = "passwordHashingIterationCount";
         private const string PASSWORDRESETFREQUENCY = "passwordResetFrequency";
         private const string VERIFICATIONKEYLIFETIME = "verificationKeyLifetime";
+        private const string ALLOWUNVERIFIEDACCOUNTSWINDOW = "allowUnverifiedAccountsWindow";
 
         [ConfigurationProperty(MULTITENANT, DefaultValue = MembershipRebootConstants.SecuritySettingDefaults.MultiTenant)]
         public bool MultiTenant
@@ -143,6 +144,13 @@ namespace BrockAllen.MembershipReboot
         {
             get { return (TimeSpan)this[VERIFICATIONKEYLIFETIME]; }
             set { this[VERIFICATIONKEYLIFETIME] = value; }
+        }
+
+        [ConfigurationProperty(ALLOWUNVERIFIEDACCOUNTSWINDOW)]
+        public TimeSpan? AllowUnverifiedAccountsWindow
+        {
+            get { return (TimeSpan?)this[ALLOWUNVERIFIEDACCOUNTSWINDOW]; }
+            set { this[ALLOWUNVERIFIEDACCOUNTSWINDOW] = value; }
         }
     }
 }


### PR DESCRIPTION
This changeset enables the option to allow newly created users to access
their accounts, for a pre-defined period of time, before the account
(email) is verified.
